### PR TITLE
Version 2.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
-All notable changes to the project will be documented in this file.
+All notable changes to the project are documented in this file.
+
+## Version 2.7.0
+
+* **[2024-12-25 05:49:23 CST]** Expose the Guzzle HTTP Middleware stack to thirdparty developers.
+* **[2024-12-25 05:48:48 CST]** Upgraded to phpexperts/dockerize v12.
 
 ## Version 2.6.0
 
@@ -9,14 +14,14 @@ All notable changes to the project will be documented in this file.
 
 ## Version 2.5.0
 
-* **[2023-01-30 10:22:26 CDT]** Removed the need to override the RESTAuth methods.
-* **[2023-01-30 10:21:58 CDT]** [m] Upgraded to phpunit v9.5.
-* **[2023-01-30 09:57:09 CDT]** Added a NoAuth class.
+* **[2023-01-30 10:22:26 CST]** Removed the need to override the RESTAuth methods.
+* **[2023-01-30 10:21:58 CST]** [m] Upgraded to phpunit v9.5.
+* **[2023-01-30 09:57:09 CST]** Added a NoAuth class.
 
 ## Version 2.4.2
 
-* **[2023-01-21 12:22:01 CDT]** [m] Added a composer file for the upcoming PHPUnit v10.
-* **[2023-01-21 11:57:15 CDT]** [m] Migrated the phpunit.xml for PHPUnit 9.3.
+* **[2023-01-21 12:22:01 CST]** [m] Added a composer file for the upcoming PHPUnit v10.
+* **[2023-01-21 11:57:15 CST]** [m] Migrated the phpunit.xml for PHPUnit 9.3.
 * **[2022-10-29 21:12:00 CDT]** Added a Google ReCAPTCHA v3 example.
 
 ## Version 2.4.1

--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ composer require phpexperts/rest-speaker
 
 ## Change log
 
+**Version 2.7.0**
+
+* **[2024-12-25 05:49:23 CST]** Expose the Guzzle HTTP Middleware stack to thirdparty developers.
+* **[2024-12-25 05:48:48 CST]** Upgraded to phpexperts/dockerize v12.
+
+
 **Version 2.6.0**
 
 * **[2024-03-29 20:03:40 CDT]** Return the raw data if it is not JSON.

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,8 @@
         "rest",
         "restful",
         "php",
-        "api"
+        "api",
+        "json"
     ],
     "homepage": "https://www.phpexperts.pro/",
     "license": "MIT",
@@ -34,7 +35,7 @@
         "phpstan/phpstan": "*",
         "symfony/var-dumper": "*",
         "phpexperts/laravel-env-polyfill": "*",
-        "phpexperts/dockerize": "*",
+        "phpexperts/dockerize": "^12.0",
         "vlucas/phpdotenv": "^5.4",
         "octoper/cuzzle": "^3.1",
         "monolog/monolog": "^2.8"

--- a/src/HTTPSpeaker.php
+++ b/src/HTTPSpeaker.php
@@ -41,6 +41,9 @@ class HTTPSpeaker implements ClientInterface
     /** @var Response|null */
     protected $lastResponse;
 
+    /** @var HandlerStack */
+    public $guzzleMiddlewareStack;
+
     /** @var TestHandler */
     public $testHandler;
 
@@ -48,21 +51,21 @@ class HTTPSpeaker implements ClientInterface
 
     public function __construct(string $baseURI = '', iGuzzleClient $guzzle = null)
     {
-        $handler = null;
+        $this->guzzleMiddlewareStack = HandlerStack::create();;
         if ($this->enableCuzzle && class_exists(CurlFormatterMiddleware::class)) {
             $testHandler = new TestHandler();
 
             $logger = new Logger('guzzle.to.curl');
             $logger->pushHandler($testHandler);
-            $handler = HandlerStack::create();
-            $handler->after('cookies', new CurlFormatterMiddleware($logger)); //add the cURL formatter middleware
+
+            $this->guzzleMiddlewareStack->after('cookies', new CurlFormatterMiddleware($logger)); //add the cURL formatter middleware
             $this->testHandler = $testHandler;
         }
 
         if (!$guzzle) {
             $guzzle = new GuzzleClient([
                 'base_uri' => $baseURI,
-                'handler' => $handler,
+                'handler' => $this->guzzleMiddlewareStack,
                 'version' => '2.0',
             ]);
         }


### PR DESCRIPTION
* **[2024-12-25 05:49:23 CST]** Expose the Guzzle HTTP Middleware stack to thirdparty developers.
* **[2024-12-25 05:48:48 CST]** Upgraded to phpexperts/dockerize v12.